### PR TITLE
CountedReadySignal: expose counter

### DIFF
--- a/counted.js
+++ b/counted.js
@@ -5,13 +5,13 @@ var ReadySignal = require('./index.js');
 module.exports = CountedReadySignal;
 
 function CountedReadySignal(n) {
-    var counter = n;
     var ready = ReadySignal();
+    ready.counter = n;
 
     var oldSignal = ready.signal;
 
     ready.signal = function newSignal() {
-        if (--counter === 0) {
+        if (--ready.counter === 0) {
             oldSignal.apply(this, arguments);
         }
     };


### PR DESCRIPTION
This allows to incrementally build / amend the count easily, consider:

```javascript
var thingsToInit = [...];
var ready = CountedReadySignal(things.length); // these are easy to predict

// but what about
if (someOption) {
  ready.counter++;
  doSomeAsyncThing(ready.signal);
}

thingsToInit.forEach(function each(thing) {
  thing.setup(ready.signal);
});
```

Without this change, we'd need:
```javascript
var count = things.length;

if (someOption) {
  count++;
  doSomeAsyncThing(function lateBindReadySignal() {
    ready.signal();
  });
}

var ready = CountedReadySignal(count);
...
```

r @Raynos 